### PR TITLE
Fix #9, Almalinux minimal build

### DIFF
--- a/al-mini/Dockerfile
+++ b/al-mini/Dockerfile
@@ -1,0 +1,13 @@
+FROM almalinux:8.4 as builder
+
+RUN mkdir /mnt/alma-root; \
+    dnf install --installroot /mnt/alma-root  --releasever 8 --setopt install_weak_deps=false --nodocs -y coreutils-single microdnf; \
+    rm -rf /mnt/alma-root/var/cache/* ; \
+    dnf clean all; \
+    cp /etc/yum.repos.d/* /mnt/alma-root/etc/yum.repos.d/ ; \
+    rm -rf /var/cache/yum
+
+# Almalinux minimal build
+FROM scratch 
+COPY --from=builder /mnt/alma-root/ /
+CMD /bin/sh

--- a/al-mini/Dockerfile
+++ b/al-mini/Dockerfile
@@ -10,7 +10,16 @@ RUN mkdir /mnt/alma-root; \
     rm -rf /mnt/alma-root/var/cache/* ; \
     dnf clean all; \
     cp /etc/yum.repos.d/* /mnt/alma-root/etc/yum.repos.d/ ; \
-    rm -rf /var/cache/yum
+    rm -rf /var/cache/yum; \
+    # generate build time file for compatibility with CentOS
+    /bin/date +%Y%m%d_%H%M > /mnt/alma-root/etc/BUILDTIME ;\
+    # set DNF infra variable to container for compatibility with CentOS
+    echo 'container' > /mnt/alma-root/etc/dnf/vars/infra; \
+    # install only en_US.UTF-8 locale files, see
+    # https://fedoraproject.org/wiki/Changes/Glibc_locale_subpackaging for details
+    echo '%_install_langs en_US.UTF-8' > /mnt/alma-root/etc/rpm/macros.image-language-conf ;\
+    > /mnt/alma-root/etc/machine-id
+
 
 # Almalinux minimal build
 FROM scratch 

--- a/al-mini/Dockerfile
+++ b/al-mini/Dockerfile
@@ -1,7 +1,12 @@
 FROM almalinux:8.4 as builder
 
 RUN mkdir /mnt/alma-root; \
-    dnf install --installroot /mnt/alma-root  --releasever 8 --setopt install_weak_deps=false --nodocs -y coreutils-single microdnf; \
+    dnf install --installroot /mnt/alma-root  --releasever 8 --setopt install_weak_deps=false --nodocs -y coreutils-single \
+    glibc-minimal-langpack \
+    json-glib \
+    langpacks-en \
+    microdnf \
+    rootfiles; \
     rm -rf /mnt/alma-root/var/cache/* ; \
     dnf clean all; \
     cp /etc/yum.repos.d/* /mnt/alma-root/etc/yum.repos.d/ ; \
@@ -10,4 +15,16 @@ RUN mkdir /mnt/alma-root; \
 # Almalinux minimal build
 FROM scratch 
 COPY --from=builder /mnt/alma-root/ /
-CMD /bin/sh
+LABEL org.label-schema.schema-version="1.0" \
+    maintainer="AlmaLinux SIG Team" \
+    org.opencontainers.image.authors="Bala Raman <srbala at gmail>" \
+    org.opencontainers.image.description="AlmaLinux Minimal Image, Base kernel with microdnf installer" \
+    org.label-schema.name="AlmaLinux Base Image Minimal" \
+    org.label-schema.vendor="AlmaLinux OS Foundation" \
+    org.label-schema.license="MIT" \
+    org.label-schema.build-date="20210614" \
+    org.opencontainers.image.title="AlmaLinux Base Image Minimal" \
+    org.opencontainers.image.vendor="AlmaLinux OS Foundation" \
+    org.opencontainers.image.licenses="MIT" \
+    org.opencontainers.image.created="2021-06-14 00:00:00+01:00"
+CMD ["/bin/bash"]

--- a/al-mini/Dockerfile
+++ b/al-mini/Dockerfile
@@ -24,16 +24,5 @@ RUN mkdir /mnt/alma-root; \
 # Almalinux minimal build
 FROM scratch 
 COPY --from=builder /mnt/alma-root/ /
-LABEL org.label-schema.schema-version="1.0" \
-    maintainer="AlmaLinux SIG Team" \
-    org.opencontainers.image.authors="Bala Raman <srbala at gmail>" \
-    org.opencontainers.image.description="AlmaLinux Minimal Image, Base kernel with microdnf installer" \
-    org.label-schema.name="AlmaLinux Base Image Minimal" \
-    org.label-schema.vendor="AlmaLinux OS Foundation" \
-    org.label-schema.license="MIT" \
-    org.label-schema.build-date="20210614" \
-    org.opencontainers.image.title="AlmaLinux Base Image Minimal" \
-    org.opencontainers.image.vendor="AlmaLinux OS Foundation" \
-    org.opencontainers.image.licenses="MIT" \
-    org.opencontainers.image.created="2021-06-14 00:00:00+01:00"
+
 CMD ["/bin/bash"]

--- a/al-mini/Readme.md
+++ b/al-mini/Readme.md
@@ -1,11 +1,85 @@
-# Almalinux Minimal Image
+# AlmaLinux Minimal Image
 
 Experimental minimal container image for Alma linux.
 
-## Local Build
+## Local Container Build
 
 Building container image locally using docker
 
 ```sh
 docker build -t almalinux:8-minimal - < Dockerfile
 ```
+
+## Comparing AlmaLinux Minimal Vs UBI Minimal
+
+Use following commands to compare AlmaLinux Minimal image with UBI minimal.
+
+### Get UBI Minimal
+
+Use docker pull `registry.access.redhat.com/ubi8/ubi-minimal:8.4` for image package verifications.
+
+```sh
+docker pull registry.access.redhat.com/ubi8/ubi-minimal:8.4
+```
+
+### UBI Minimal Packages
+
+First run UBI Mimimal continer, then use `rpm -qa` command to get list of packages, sort and store it locally for later comparision.
+
+```sh
+$ docker run --rm -it -v $PWD:/mydata registry.access.redhat.com/ubi8/ubi-minimal:8.4
+[root@70c08cf3c6a0 /]# rpm -qa | sort > /mydata/ubi-mini.txt
+[root@70c08cf3c6a0 /]# exit
+```
+
+### AlmaLinux Minimal Packages
+
+Repeat `rpm` and `sort` commands in AlmaLinux contianer to get packages to compare in next step.
+
+```sh
+$ docker run --rm -it -v $PWD:/mydata almalinux:8-minimal 
+[root@b0f53298e48c /]# rpm -qa | sort > /mydata/al-mini.txt
+[root@b0f53298e48c /]# exit
+```
+
+### Diff Alma vs UBI
+
+Image packages exported from previous steps are available in current working directory
+
+```sh
+$ ls -al *mini.txt
+-rw-r--r--  1 srbala  staff  3071 Jun 14 18:45 al-mini.txt
+-rw-r--r--  1 srbala  staff  3111 Jun 14 18:43 ubi-mini.txt
+```
+
+Someof the packages from AlmoLinux contains `.alma`, clean it prior to compare
+
+```sh
+sed -i 's/.alma././g' al-mini.txt
+```
+
+Use following in OSX to avoid command error
+
+```sh
+sed -i '' 's/.alma././g' al-mini.txt
+```
+
+Now compare using `diff` command.
+
+```sh
+$ diff al-mini.txt ubi-mini.txt 
+1d0
+< almalinux-release-8.4-2.el8.x86_64
+26c25,26
+< gpg-pubkey-3abb34f8-5ffd890e
+---
+> gpg-pubkey-d4082792-5b32db75
+> gpg-pubkey-fd431d51-4ae0493b
+59a60
+> librhsm-0.0.3-4.el8.x86_64
+93a95
+> redhat-release-8.4-0.6.el8.x86_64
+```
+
+Difference in package are acceptable, since they are specific to package/vendor.
+

--- a/al-mini/Readme.md
+++ b/al-mini/Readme.md
@@ -1,0 +1,11 @@
+# Almalinux Minimal Image
+
+Experimental minimal container image for Alma linux.
+
+## Local Build
+
+Building container image locally using docker
+
+```sh
+docker build -t almalinux:8-minimal - < Dockerfile
+```


### PR DESCRIPTION
Added Dockerfile for minimal package.

This is a multi stage appraoch for disucussion. Size of the container is 106MB. 

The folder `/mnt/alma-root` can be compressed as a `tar.gz` and used to create container in Docker file.

Signed-off-by: Bala Raman <srbala@gmail.com>