### PR TITLE
Fix #13, Adding Init and Micro KS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/work
+/output

--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ show_usage() {
     echo -e 'Usage: build.sh [OPTION]...\n'
     echo '  -h        show this message and exit'
     echo '  -o        output directory path. Default is "./result"'
-    echo '  -t        build type (either "default" or "minimal")'
+    echo '  -t        image build type like "default", "init", "micro", "minimal". Default is "default"'
 }
 
 
@@ -43,7 +43,7 @@ while getopts "ho:t:" opt; do
             ;;
         t)
             case "${OPTARG}" in
-                default|minimal)
+                default|init|micro|minimal)
                     TYPE="${OPTARG}"
                     ;;
                 *)

--- a/kickstarts/almalinux-8-init.aarch64.ks
+++ b/kickstarts/almalinux-8-init.aarch64.ks
@@ -1,0 +1,142 @@
+# AlmaLinux 8 kickstart file for aarch64 base Docker image
+
+# install
+url --url https://repo.almalinux.org/almalinux/8/BaseOS/aarch64/os/
+
+lang en_US.UTF-8
+keyboard us
+timezone --nontp --utc UTC
+
+network --activate --bootproto=dhcp --device=link --onboot=on
+firewall --disabled
+selinux --disabled
+
+bootloader --disable
+zerombr
+clearpart --all --initlabel
+autopart --fstype=ext4 --type=plain --nohome --noboot --noswap
+
+rootpw --iscrypted --lock almalinux
+
+shutdown
+
+%packages --ignoremissing --excludedocs --instLangs=en --nocore --excludeWeakdeps
+almalinux-release
+bash
+brotli
+coreutils-single
+crypto-policies-scripts
+cryptsetup-libs
+dbus
+dbus-common
+dbus-daemon
+dbus-tools
+device-mapper
+device-mapper-libs
+dmidecode
+dnf
+dnf-plugin-subscription-manager
+findutils
+glibc-minimal-langpack
+gdb-gdbserver
+gobject-introspection
+libcurl
+libuser
+librhsm
+passwd
+procps-ng
+publicsuffix-list-dafsa-20180723-1
+python3-chardet
+python3-dateutil
+python3-dbus
+python3-decorator
+python3-dmidecode
+python3-dnf-plugins-core
+python3-ethtool
+python3-gobject-base
+python3-idna
+python3-iniparse
+python3-inotify
+python3-librepo
+python3-libxml2
+python3-pysocks
+python3-requests
+python3-six
+python3-subscription-manager-rhsm
+python3-syspurpose
+python3-urllib3
+rdma-core
+rootfiles
+tar
+subscription-manager
+systemd
+systemd-pam
+tpm2-tss
+usermode
+vim-minimal
+virt-what
+which
+yum
+
+-binutils
+-diffutils
+-elfutils-debuginfod-client
+-firewalld
+-gettext*
+-glibc-langpack-en
+-gnupg2-smime
+-grub\*
+-hostname
+-iputils
+-kernel
+-less
+-libevent
+-openssl
+-os-prober
+-open-vm-tools
+-pinentry
+-platform-python-pip
+-shared-mime-info
+-trousers
+-unbound-libs
+-xkeyboard-config
+-xz
+%end
+
+
+%post --erroronfail --log=/root/anaconda-post.log
+# generate build time file for compatibility with CentOS
+/bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
+
+# set DNF infra variable to container for compatibility with CentOS
+echo 'container' > /etc/dnf/vars/infra
+
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+
+# install only en_US.UTF-8 locale files, see
+# https://fedoraproject.org/wiki/Changes/Glibc_locale_subpackaging for details
+echo '%_install_langs en_US.UTF-8' > /etc/rpm/macros.image-language-conf
+
+# force each container to have a unique machine-id
+> /etc/machine-id
+
+# create tmp directories because there is no tmpfs support in Docker
+umount /run
+systemd-tmpfiles --create --boot
+
+# disable login prompt and mounts
+systemctl mask console-getty.service \
+               dev-hugepages.mount \
+               getty.target \
+               systemd-logind.service \
+               sys-fs-fuse-connections.mount \
+               systemd-remount-fs.service
+
+# remove unnecessary files
+rm -f /var/lib/dnf/history.* \
+      /run/nologin
+rm -fr /var/log/* \
+       /tmp/* /tmp/.* \
+       /boot || true
+%end

--- a/kickstarts/almalinux-8-init.x86_64.ks
+++ b/kickstarts/almalinux-8-init.x86_64.ks
@@ -1,0 +1,142 @@
+# AlmaLinux 8 kickstart file for x86_64 base Docker image
+
+# install
+url --url https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/
+
+lang en_US.UTF-8
+keyboard us
+timezone --nontp --utc UTC
+
+network --activate --bootproto=dhcp --device=link --onboot=on
+firewall --disabled
+selinux --disabled
+
+bootloader --disable
+zerombr
+clearpart --all --initlabel
+autopart --fstype=ext4 --type=plain --nohome --noboot --noswap
+
+rootpw --iscrypted --lock almalinux
+
+shutdown
+
+%packages --ignoremissing --excludedocs --instLangs=en --nocore --excludeWeakdeps
+almalinux-release
+bash
+brotli
+coreutils-single
+crypto-policies-scripts
+cryptsetup-libs
+dbus
+dbus-common
+dbus-daemon
+dbus-tools
+device-mapper
+device-mapper-libs
+dmidecode
+dnf
+dnf-plugin-subscription-manager
+findutils
+glibc-minimal-langpack
+gdb-gdbserver
+gobject-introspection
+libcurl
+libuser
+librhsm
+passwd
+procps-ng
+publicsuffix-list-dafsa-20180723-1
+python3-chardet
+python3-dateutil
+python3-dbus
+python3-decorator
+python3-dmidecode
+python3-dnf-plugins-core
+python3-ethtool
+python3-gobject-base
+python3-idna
+python3-iniparse
+python3-inotify
+python3-librepo
+python3-libxml2
+python3-pysocks
+python3-requests
+python3-six
+python3-subscription-manager-rhsm
+python3-syspurpose
+python3-urllib3
+rdma-core
+rootfiles
+tar
+subscription-manager
+systemd
+systemd-pam
+tpm2-tss
+usermode
+vim-minimal
+virt-what
+which
+yum
+
+-binutils
+-diffutils
+-elfutils-debuginfod-client
+-firewalld
+-gettext*
+-glibc-langpack-en
+-gnupg2-smime
+-grub\*
+-hostname
+-iputils
+-kernel
+-less
+-libevent
+-openssl
+-os-prober
+-open-vm-tools
+-pinentry
+-platform-python-pip
+-shared-mime-info
+-trousers
+-unbound-libs
+-xkeyboard-config
+-xz
+%end
+
+
+%post --erroronfail --log=/root/anaconda-post.log
+# generate build time file for compatibility with CentOS
+/bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
+
+# set DNF infra variable to container for compatibility with CentOS
+echo 'container' > /etc/dnf/vars/infra
+
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+
+# install only en_US.UTF-8 locale files, see
+# https://fedoraproject.org/wiki/Changes/Glibc_locale_subpackaging for details
+echo '%_install_langs en_US.UTF-8' > /etc/rpm/macros.image-language-conf
+
+# force each container to have a unique machine-id
+> /etc/machine-id
+
+# create tmp directories because there is no tmpfs support in Docker
+umount /run
+systemd-tmpfiles --create --boot
+
+# disable login prompt and mounts
+systemctl mask console-getty.service \
+               dev-hugepages.mount \
+               getty.target \
+               systemd-logind.service \
+               sys-fs-fuse-connections.mount \
+               systemd-remount-fs.service
+
+# remove unnecessary files
+rm -f /var/lib/dnf/history.* \
+      /run/nologin
+rm -fr /var/log/* \
+       /tmp/* /tmp/.* \
+       /boot || true
+%end

--- a/kickstarts/almalinux-8-micro.aarch64.ks
+++ b/kickstarts/almalinux-8-micro.aarch64.ks
@@ -1,0 +1,97 @@
+# AlmaLinux 8 kickstart file for aarch64 base Docker image
+
+# install
+url --url https://repo.almalinux.org/almalinux/8/BaseOS/aarch64/os/
+
+lang en_US.UTF-8
+keyboard us
+timezone --nontp --utc UTC
+
+network --activate --bootproto=dhcp --device=link --onboot=on
+firewall --disabled
+selinux --disabled
+
+bootloader --disable
+zerombr
+clearpart --all --initlabel
+autopart --fstype=ext4 --type=plain --nohome --noboot --noswap
+
+rootpw --iscrypted --lock almalinux
+
+shutdown
+
+%packages --ignoremissing --excludedocs --instLangs=en --nocore --excludeWeakdeps
+coreutils-single
+glibc-minimal-langpack
+
+-binutils
+-brotli
+-dnf
+-findutils
+-crypto-policies-scripts
+-diffutils
+-elfutils-debuginfod-client
+-firewalld
+-gettext*
+-glibc-langpack-en
+-gnupg2-smime
+-grub\*
+-hostname
+-iptables
+-iputils
+-langpacks-en
+-kernel
+-libevent
+-less
+-openssl
+-os-prober
+-open-vm-tools
+-pinentry
+-platform-python-pip
+-shared-mime-info
+-tar
+-trousers
+-unbound-libs
+-vim-minimal
+-xkeyboard-config
+-xz
+-yum
+%end
+
+
+%post --erroronfail --log=/root/anaconda-post.log
+# generate build time file for compatibility with CentOS
+/bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
+
+# set DNF infra variable to container for compatibility with CentOS
+echo 'container' > /etc/dnf/vars/infra
+
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+
+# install only en_US.UTF-8 locale files, see
+# https://fedoraproject.org/wiki/Changes/Glibc_locale_subpackaging for details
+echo '%_install_langs en_US.UTF-8' > /etc/rpm/macros.image-language-conf
+
+# force each container to have a unique machine-id
+> /etc/machine-id
+
+# create tmp directories because there is no tmpfs support in Docker
+umount /run
+systemd-tmpfiles --create --boot
+
+# disable login prompt and mounts
+systemctl mask console-getty.service \
+               dev-hugepages.mount \
+               getty.target \
+               systemd-logind.service \
+               sys-fs-fuse-connections.mount \
+               systemd-remount-fs.service
+
+# remove unnecessary files
+rm -f /var/lib/dnf/history.* \
+      /run/nologin
+rm -fr /var/log/* \
+       /tmp/* /tmp/.* \
+       /boot || true
+%end

--- a/kickstarts/almalinux-8-micro.x86_64.ks
+++ b/kickstarts/almalinux-8-micro.x86_64.ks
@@ -1,0 +1,97 @@
+# AlmaLinux 8 kickstart file for x86_64 base Docker image
+
+# install
+url --url https://repo.almalinux.org/almalinux/8/BaseOS/x86_64/os/
+
+lang en_US.UTF-8
+keyboard us
+timezone --nontp --utc UTC
+
+network --activate --bootproto=dhcp --device=link --onboot=on
+firewall --disabled
+selinux --disabled
+
+bootloader --disable
+zerombr
+clearpart --all --initlabel
+autopart --fstype=ext4 --type=plain --nohome --noboot --noswap
+
+rootpw --iscrypted --lock almalinux
+
+shutdown
+
+%packages --ignoremissing --excludedocs --instLangs=en --nocore --excludeWeakdeps
+coreutils-single
+glibc-minimal-langpack
+
+-binutils
+-brotli
+-dnf
+-findutils
+-crypto-policies-scripts
+-diffutils
+-elfutils-debuginfod-client
+-firewalld
+-gettext*
+-glibc-langpack-en
+-gnupg2-smime
+-grub\*
+-hostname
+-iptables
+-iputils
+-langpacks-en
+-kernel
+-libevent
+-less
+-openssl
+-os-prober
+-open-vm-tools
+-pinentry
+-platform-python-pip
+-shared-mime-info
+-tar
+-trousers
+-unbound-libs
+-vim-minimal
+-xkeyboard-config
+-xz
+-yum
+%end
+
+
+%post --erroronfail --log=/root/anaconda-post.log
+# generate build time file for compatibility with CentOS
+/bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
+
+# set DNF infra variable to container for compatibility with CentOS
+echo 'container' > /etc/dnf/vars/infra
+
+# import AlmaLinux PGP key
+rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+
+# install only en_US.UTF-8 locale files, see
+# https://fedoraproject.org/wiki/Changes/Glibc_locale_subpackaging for details
+echo '%_install_langs en_US.UTF-8' > /etc/rpm/macros.image-language-conf
+
+# force each container to have a unique machine-id
+> /etc/machine-id
+
+# create tmp directories because there is no tmpfs support in Docker
+umount /run
+systemd-tmpfiles --create --boot
+
+# disable login prompt and mounts
+systemctl mask console-getty.service \
+               dev-hugepages.mount \
+               getty.target \
+               systemd-logind.service \
+               sys-fs-fuse-connections.mount \
+               systemd-remount-fs.service
+
+# remove unnecessary files
+rm -f /var/lib/dnf/history.* \
+      /run/nologin
+rm -fr /var/log/* \
+       /tmp/* /tmp/.* \
+       /boot || true
+%end


### PR DESCRIPTION

 * Added kickstart files for `init` and `micro` packages. This will resolve the issue #13.  
 * Added `.gitignore` to exclude work and temp output fiels. 
 * Adjusted `build.sh` to accept new types

Command to build `micro` package
```sh
docker run --rm --privileged -v "$PWD:/build:z" \
    -e BUILD_KICKSTART=kickstarts/almalinux-8-micro.x86_64.ks \
    -e BUILD_ROOTFS=almalinux-8-micro-docker.x86_64.tar.gz \
    -e BUILD_OUTDIR=work/micro84 \
    almalinux/ks2rootfs
```
Command to build `init` package
```sh
docker run --rm --privileged -v "$PWD:/build:z" \
    -e BUILD_KICKSTART=kickstarts/almalinux-8-init.x86_64.ks \
    -e BUILD_ROOTFS=almalinux-8-init-docker.x86_64.tar.gz \
    -e BUILD_OUTDIR=work/init84 \
    almalinux/ks2rootfs
```