### PR TITLE
Disable Installation logs on the container

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,8 @@ livemedia-creator --no-virt --make-tar --ks "${KS_PATH}" \
                   --image-name="${IMAGE_NAME}" \
                   --project "AlmaLinux OS ${RELEASE_VER}-${TYPE} Docker" \
                   --releasever "${RELEASE_VER}" \
-                  --resultdir "${OUTPUT_DIR}"
+                  --resultdir "${OUTPUT_DIR}" \
+                  --anaconda-arg "--nosave all"
 
 # save list of packages installed
 jq .[] -r /tmp/dnf.cache/tempfiles.json | awk -F '/' '{print $5}' | sort > ${OUTPUT_DIR}/rpm-packages

--- a/kickstarts/almalinux-8-default.aarch64.ks
+++ b/kickstarts/almalinux-8-default.aarch64.ks
@@ -60,7 +60,8 @@ xz
 %end
 
 
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 

--- a/kickstarts/almalinux-8-default.x86_64.ks
+++ b/kickstarts/almalinux-8-default.x86_64.ks
@@ -60,7 +60,8 @@ xz
 %end
 
 
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 

--- a/kickstarts/almalinux-8-init.aarch64.ks
+++ b/kickstarts/almalinux-8-init.aarch64.ks
@@ -56,15 +56,9 @@ yum
 -xkeyboard-config
 %end
 
-%pre
-# Pre configure tasks for Docker
 
-# Don't add the anaconda build logs to the image
-# see /usr/share/anaconda/post-scripts/99-copy-logs.ks
-touch /tmp/NOSAVE_LOGS
-%end
-
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 

--- a/kickstarts/almalinux-8-init.x86_64.ks
+++ b/kickstarts/almalinux-8-init.x86_64.ks
@@ -56,15 +56,9 @@ yum
 -xkeyboard-config
 %end
 
-%pre
-# Pre configure tasks for Docker
 
-# Don't add the anaconda build logs to the image
-# see /usr/share/anaconda/post-scripts/99-copy-logs.ks
-touch /tmp/NOSAVE_LOGS
-%end
-
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 

--- a/kickstarts/almalinux-8-micro.aarch64.ks
+++ b/kickstarts/almalinux-8-micro.aarch64.ks
@@ -39,15 +39,9 @@ glibc-minimal-langpack
 -xkeyboard-config
 %end
 
-%pre
-# Pre configure tasks for Docker
 
-# Don't add the anaconda build logs to the image
-# see /usr/share/anaconda/post-scripts/99-copy-logs.ks
-touch /tmp/NOSAVE_LOGS
-%end
-
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 
@@ -72,7 +66,8 @@ rm -rfv /var/log/* \
        /boot || true
 %end
 
-%post --nochroot --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log --erroronfail
+# NOTE: add --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log for debugging
+%post --nochroot --erroronfail
 set -eux
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1343138

--- a/kickstarts/almalinux-8-micro.x86_64.ks
+++ b/kickstarts/almalinux-8-micro.x86_64.ks
@@ -39,15 +39,9 @@ glibc-minimal-langpack
 -xkeyboard-config
 %end
 
-%pre
-# Pre configure tasks for Docker
 
-# Don't add the anaconda build logs to the image
-# see /usr/share/anaconda/post-scripts/99-copy-logs.ks
-touch /tmp/NOSAVE_LOGS
-%end
-
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 
@@ -72,7 +66,8 @@ rm -rfv /var/log/* \
        /boot || true
 %end
 
-%post --nochroot --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log --erroronfail
+# NOTE: add --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log for debugging
+%post --nochroot --erroronfail
 set -eux
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1343138

--- a/kickstarts/almalinux-8-minimal.aarch64.ks
+++ b/kickstarts/almalinux-8-minimal.aarch64.ks
@@ -43,7 +43,8 @@ rootfiles
 -xkeyboard-config
 %end
 
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 
@@ -68,7 +69,8 @@ rm -fr /var/log/* \
        /boot || true
 %end
 
-%post --nochroot --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log --erroronfail
+# NOTE: add --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log for debugging
+%post --nochroot --erroronfail
 set -eux
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1343138

--- a/kickstarts/almalinux-8-minimal.x86_64.ks
+++ b/kickstarts/almalinux-8-minimal.x86_64.ks
@@ -43,8 +43,8 @@ rootfiles
 -xkeyboard-config
 %end
 
-
-%post --erroronfail --log=/root/anaconda-post.log
+# NOTE: add --log=/root/anaconda-post.log for debugging
+%post --erroronfail
 # generate build time file for compatibility with CentOS
 /bin/date +%Y%m%d_%H%M > /etc/BUILDTIME
 
@@ -69,7 +69,8 @@ rm -fr /var/log/* \
        /boot || true
 %end
 
-%post --nochroot --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log --erroronfail
+# NOTE: add --logfile=/mnt/sysimage/root/anaconda-post-nochroot.log for debugging
+%post --nochroot --erroronfail
 set -eux
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1343138


### PR DESCRIPTION
Don't store installation log files and kickstart files on the container.
Add instructions on how to enable post-action logging for debugging purposes.

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>