### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 RELEASE_VER='8'
 ARCH="$(uname -m)"
-OUTPUT_DIR='./result'
+OUTPUT_DIR='./result_${ARCH}'
 TYPE='default'
 
 OPTIND=1
@@ -39,7 +39,7 @@ while getopts "ho:t:" opt; do
             exit 0
             ;;
         o)
-            OUTPUT_DIR="${OPTARG}"
+            OUTPUT_DIR="${OPTARG}_${ARCH}"
             ;;
         t)
             case "${OPTARG}" in
@@ -65,7 +65,7 @@ fi
 
 
 IMAGE_NAME="almalinux-${RELEASE_VER}-docker.${TYPE}.tar.xz"
-KS_PATH="./kickstarts/almalinux-${RELEASE_VER}-${TYPE}.${ARCH}.ks"
+KS_PATH="./kickstarts/almalinux-${RELEASE_VER}-${TYPE}.ks"
 DOCKER_FILE=${OUTPUT_DIR}/Dockerfile
 
 


### PR DESCRIPTION
This PR contains two fixes ...

* Remove arch from filename
* Use arch name in output folder, this will help to run all-in-one build script