### PR TITLE
Fix for ppc64le support and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ You need an **AlmaLinux system** with following RPM packages installed to run th
 * anaconda-tui
 * lorax
 * subscription-manager (make sure the `rhsm` service is running, see [rhbz#1872902](https://bugzilla.redhat.com/show_bug.cgi?id=1872902))
+* jq
 
 ```sh
 ./build.sh -h
@@ -49,6 +50,11 @@ Use command below to create `init` docker files for `almalinux:init`container im
 
 ```sh
 ./build.sh -o init -t init
+```
+Use command below to create all type of docker images
+
+```sh
+for type in default minimal base micro init; do ./build.sh -o $type -t $type; done
 ```
 
 ### Known issues

--- a/kickstarts/almalinux-8-base.ks
+++ b/kickstarts/almalinux-8-base.ks
@@ -1,7 +1,9 @@
 # AlmaLinux 8 kickstart file for x86_64 base Docker image
 
 # install
-url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8.5/AppStream/$basearch/os/
 
 lang en_US.UTF-8
 keyboard us

--- a/kickstarts/almalinux-8-default.ks
+++ b/kickstarts/almalinux-8-default.ks
@@ -1,7 +1,9 @@
 # AlmaLinux 8 kickstart file for x86_64 base Docker image
 
 # install
-url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8.5/AppStream/$basearch/os/
 
 lang en_US.UTF-8
 keyboard us

--- a/kickstarts/almalinux-8-init.ks
+++ b/kickstarts/almalinux-8-init.ks
@@ -1,7 +1,9 @@
 # AlmaLinux 8 kickstart file for x86_64 base Docker image
 
 # install
-url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8.5/AppStream/$basearch/os/
 
 lang en_US.UTF-8
 keyboard us

--- a/kickstarts/almalinux-8-micro.ks
+++ b/kickstarts/almalinux-8-micro.ks
@@ -1,7 +1,9 @@
 # AlmaLinux 8 kickstart file for x86_64 base Docker image
 
 # install
-url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8.5/AppStream/$basearch/os/
 
 lang en_US.UTF-8
 keyboard us

--- a/kickstarts/almalinux-8-minimal.ks
+++ b/kickstarts/almalinux-8-minimal.ks
@@ -1,7 +1,9 @@
 # AlmaLinux 8 kickstart file for x86_64 base Docker image
 
 # install
-url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+url --url https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/kickstart/
+repo --name=BaseOS --baseurl=https://repo.almalinux.org/almalinux/8.5/BaseOS/$basearch/os/
+repo --name=AppStream --baseurl=https://repo.almalinux.org/almalinux/8.5/AppStream/$basearch/os/
 
 lang en_US.UTF-8
 keyboard us


### PR DESCRIPTION
* Add Installation, BaseOS and, AppStream repo URLs to avoid possible package not found error during the installation
* Add missing dependency to build images
* Add a one-liner to create all types of images

Signed-off-by: Elkhan Mammadli <elkhan.mammadli@protonmail.com>