### PR TITLE
Update kickstart files to exclude hyperv os agents package

### DIFF
--- a/kickstarts/almalinux-9-base.ks
+++ b/kickstarts/almalinux-9-base.ks
@@ -41,6 +41,7 @@ yum
 -dosfstools
 -e2fsprogs
 -gnupg2-smime
+-hyperv*
 -kernel
 -langpacks-*
 -langpacks-en

--- a/kickstarts/almalinux-9-default.ks
+++ b/kickstarts/almalinux-9-default.ks
@@ -41,6 +41,7 @@ xz
 -dosfstools
 -e2fsprogs
 -gnupg2-smime
+-hyperv*
 -kernel
 -langpacks-*
 -langpacks-en

--- a/kickstarts/almalinux-9-init.ks
+++ b/kickstarts/almalinux-9-init.ks
@@ -42,6 +42,7 @@ yum
 -dosfstools
 -e2fsprogs
 -gnupg2-smime
+-hyperv*
 -kernel
 -langpacks-*
 -langpacks-en

--- a/kickstarts/almalinux-9-micro.ks
+++ b/kickstarts/almalinux-9-micro.ks
@@ -28,6 +28,7 @@ glibc-minimal-langpack
 -e2fsprogs
 -fuse-libs
 -gnupg2-smime
+-hyperv*
 -kernel
 -langpacks-en
 -libss

--- a/kickstarts/almalinux-9-minimal.ks
+++ b/kickstarts/almalinux-9-minimal.ks
@@ -34,6 +34,7 @@ rootfiles
 -dosfstools
 -e2fsprogs
 -gnupg2-smime
+-hyperv*
 -kernel
 -langpacks-*
 -langpacks-en


### PR DESCRIPTION
Added `hyperv*` to exception list

* Update almalinux-9-base.ks
* Update almalinux-9-default.ks
* Update almalinux-9-init.ks
* Update almalinux-9-micro.ks
* Update almalinux-9-minimal.ks