### PR TITLE
Fix inaccurate diff result on podman

### DIFF
--- a/dockerfiles/al8/Dockerfile.base
+++ b/dockerfiles/al8/Dockerfile.base
@@ -11,7 +11,7 @@ RUN mkdir -p /mnt/sys-root; \
     gdb-gdbserver \
     glibc-minimal-langpack \
     gzip \
-    langpacks-en \    
+    langpacks-en \
     libuser \
     passwd \
     rootfiles \
@@ -21,9 +21,9 @@ RUN mkdir -p /mnt/sys-root; \
     vim-minimal \
     virt-what \
     which \
-    yum \ 
-    ; 
-# Additional hacks for kickstart file and backward compatable support    
+    yum \
+    ;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/var/cache/dnf/* /mnt/sys-root/var/lib/dnf/repos; \
     rm -rf /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/*  /mnt/sys-root/run/blkid ; \
     mkdir -p /mnt/sys-root/run/lock; \
@@ -35,7 +35,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/.pwd.lock; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     touch /mnt/sys-root/run/utmp ;\
-    chmod 664 /mnt/sys-root/run/utmp ;\    
+    chmod 664 /mnt/sys-root/run/utmp ;\
     echo '0.0 0 0.0' > /mnt/sys-root/etc/adjtime; \
     echo '0' >> /mnt/sys-root/etc/adjtime; \
     echo 'UTC' >> /mnt/sys-root/etc/adjtime; \
@@ -46,7 +46,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/machine-id;
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
 
 FROM scratch as stage2
 
@@ -67,4 +68,3 @@ COPY --from=stage2 / /
 ENV LANG=C.utf8
 
 CMD ["/bin/bash"]
-

--- a/dockerfiles/al8/Dockerfile.default
+++ b/dockerfiles/al8/Dockerfile.default
@@ -11,7 +11,7 @@ RUN mkdir /mnt/sys-root; \
     coreutils-single \
     dnf \
     findutils \
-    glibc-minimal-langpack \ 
+    glibc-minimal-langpack \
     hostname \
     iputils \
     langpacks-en \
@@ -21,10 +21,10 @@ RUN mkdir /mnt/sys-root; \
     tar \
     vim-minimal \
     yum \
-    xz \ 
+    xz \
     ; \
     dnf --installroot /mnt/sys-root clean all; \
-# Additional hacks for kickstart file and backward compatable support    
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* ; \
     rm -rf /mnt/sys-root/var/cache/dnf/* /mnt/sys-root/var/lib/dnf/repos /mnt/sys-root/boot /mnt/sys-root/dev/null ; \
     rm -rf /mnt/sys-root/var/lib/dnf/history* /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/var/log/*  ; \
@@ -47,7 +47,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* ; \
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     rm -rf /mnt/sys-root/usr/share/locale/en_US@piglati* /mnt/sys-root/run/blkid  ; \
     rm -f /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/machine-id; 
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
 
 FROM scratch as stage2
 COPY --from=system-build /mnt/sys-root/ /
@@ -58,9 +59,9 @@ RUN systemctl set-default multi-user.target; \
     sys-fs-fuse-connections.mount \
     systemd-logind.service \
     getty.target \
-    console-getty.service ; 
+    console-getty.service ;
 
-FROM scratch 
+FROM scratch
 COPY --from=stage2 / /
 
 ENV LANG=C.utf8

--- a/dockerfiles/al8/Dockerfile.i686
+++ b/dockerfiles/al8/Dockerfile.i686
@@ -17,7 +17,7 @@ RUN mkdir /mnt/sys-root; \
     coreutils-single \
     dnf \
     findutils \
-    glibc-minimal-langpack \ 
+    glibc-minimal-langpack \
     hostname \
     iputils \
     langpacks-en \
@@ -27,7 +27,7 @@ RUN mkdir /mnt/sys-root; \
     tar \
     vim-minimal \
     yum \
-    xz \ 
+    xz \
     ; \
     dnf --installroot /mnt/sys-root clean all; \
     rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.*; \
@@ -40,10 +40,11 @@ RUN mkdir /mnt/sys-root; \
     echo 'LANG="C.utf8"' >  /mnt/sys-root/etc/locale.conf; \
     echo 'container' > c/etc/dnf/vars/infra; \
     rm -f /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/machine-id;
-    
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
+
 # Build a fresh container image using COPY
-FROM scratch 
+FROM scratch
 COPY --from=system-build /mnt/sys-root/ /
 
 ENV LANG=C.utf8
@@ -57,4 +58,3 @@ RUN systemctl set-default multi-user.target; \
     console-getty.service
 
 CMD ["/bin/bash"]
-

--- a/dockerfiles/al8/Dockerfile.init
+++ b/dockerfiles/al8/Dockerfile.init
@@ -11,7 +11,7 @@ RUN mkdir -p /mnt/sys-root; \
     gdb-gdbserver \
     glibc-minimal-langpack \
     gzip \
-    langpacks-en \    
+    langpacks-en \
     libuser \
     passwd \
     procps-ng \
@@ -22,9 +22,9 @@ RUN mkdir -p /mnt/sys-root; \
     vim-minimal \
     virt-what \
     which \
-    yum \ 
-    ; 
-# Additional hacks for kickstart file and backward compatable support    
+    yum \
+    ;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/var/cache/dnf/* /mnt/sys-root/var/lib/dnf/repos; \
     rm -rf /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/*  /mnt/sys-root/run/blkid ; \
     mkdir -p /mnt/sys-root/run/lock; \
@@ -36,7 +36,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/.pwd.lock; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     touch /mnt/sys-root/run/utmp ;\
-    chmod 664 /mnt/sys-root/run/utmp ;\    
+    chmod 664 /mnt/sys-root/run/utmp ;\
     echo '0.0 0 0.0' > /mnt/sys-root/etc/adjtime; \
     echo '0' >> /mnt/sys-root/etc/adjtime; \
     echo 'UTC' >> /mnt/sys-root/etc/adjtime; \
@@ -47,13 +47,14 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/machine-id;
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
 
 FROM scratch  as stage2
 
 COPY --from=system-build /mnt/sys-root/ /
 
-ENV LANG=C.utf8 
+ENV LANG=C.utf8
 
 RUN systemctl set-default multi-user.target; \
     systemctl mask systemd-remount-fs.service \
@@ -71,7 +72,7 @@ FROM scratch
 
 COPY --from=stage2 / /
 
-ENV LANG=C.utf8 
+ENV LANG=C.utf8
 
 CMD ["/sbin/init"]
 

--- a/dockerfiles/al8/Dockerfile.micro
+++ b/dockerfiles/al8/Dockerfile.micro
@@ -4,8 +4,8 @@ FROM ${SYSBASE} as system-build
 RUN mkdir -p /mnt/sys-root; \
     dnf install --installroot /mnt/sys-root coreutils-single glibc-minimal-langpack \
     --releasever 8 --setopt install_weak_deps=false --nodocs -y; \
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support 
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/lib/dnf /mnt/sys-root/var/log/yum.*; \
     /bin/date +%Y%m%d_%H%M > /mnt/sys-root/etc/BUILDTIME ;  \
     echo '%_install_langs C.utf8' > /mnt/sys-root/etc/rpm/macros.image-language-conf; \
@@ -14,6 +14,7 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/.pwd.lock; \
+    touch /mnt/sys-root/etc/resolv.conf; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     rm -rf /mnt/sys-root/usr/share/locale/en* /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/hawkey.log ; \
     echo '0.0 0 0.0' > /mnt/sys-root/etc/adjtime; \
@@ -25,11 +26,10 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     echo 'KEYMAP="us"' > /mnt/sys-root/etc/vconsole.conf; \
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     cd /mnt/sys-root/etc ; \
-    ln -s ../usr/share/zoneinfo/UTC localtime 
+    ln -s ../usr/share/zoneinfo/UTC localtime
 
 FROM scratch
 
 COPY --from=system-build /mnt/sys-root/ /
 
 CMD /bin/sh
-

--- a/dockerfiles/al8/Dockerfile.minimal
+++ b/dockerfiles/al8/Dockerfile.minimal
@@ -13,8 +13,8 @@ RUN mkdir /mnt/sys-root; \
     libusbx \
     langpacks-en \
     rootfiles; \
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support    
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/lib/dnf/repos; \
     rm -rf /mnt/sys-root/var/lib/dnf/history* /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/run/*; \
     mkdir -p /mnt/sys-root/run/lock; \
@@ -36,12 +36,12 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf; \
     cd /mnt/sys-root/etc ; \
-    ln -s ../usr/share/zoneinfo/UTC localtime 
+    ln -s ../usr/share/zoneinfo/UTC localtime
 
 # Almalinux minimal build
 FROM scratch
 COPY --from=builder /mnt/sys-root/ /
 
 CMD ["/bin/bash"]
-

--- a/dockerfiles/al9/Dockerfile.base
+++ b/dockerfiles/al9/Dockerfile.base
@@ -16,12 +16,12 @@ RUN mkdir -p /mnt/sys-root; \
     libcurl-minimal \
     libusbx \
     rootfiles \
-    systemd \    
+    systemd \
     tar \
     usermode \
     vim-minimal \
     virt-what \
-    yum \   
+    yum \
     ; \
     echo '%_install_langs en_US.UTF-8' > /etc/rpm/macros.image-language-conf ;\
     dnf reinstall -y \
@@ -29,9 +29,9 @@ RUN mkdir -p /mnt/sys-root; \
     --releasever 9 \
     --setopt install_weak_deps=false \
     --nodocs \
-    krb5-libs ; \      
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support    
+    krb5-libs ; \
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/var/cache/dnf/* /mnt/sys-root/var/lib/dnf/repos; \
     rm -rf /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/*  /mnt/sys-root/run/blkid ; \
     mkdir -p /mnt/sys-root/run/lock; \
@@ -43,7 +43,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/.pwd.lock; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     touch /mnt/sys-root/run/utmp ;\
-    chmod 664 /mnt/sys-root/run/utmp ;\    
+    chmod 664 /mnt/sys-root/run/utmp ;\
     echo '0.0 0 0.0' > /mnt/sys-root/etc/adjtime; \
     echo '0' >> /mnt/sys-root/etc/adjtime; \
     echo 'UTC' >> /mnt/sys-root/etc/adjtime; \
@@ -54,8 +54,9 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id /mnt/sys-root/var/cache/dnf/.gpgkeyschecked.yum ; \
-    touch /mnt/sys-root/etc/machine-id;
-# AL9 specific hacks    
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
+# AL9 specific hacks
 RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump /mnt/sys-root/var/lib/tpm2-tss/system/keystore ;\
     mkdir -p /mnt/sys-root/run/cryptsetup /mnt/sys-root/run/lock/subsys /mnt/sys-root/run/log /mnt/sys-root/run/user /mnt/sys-root/run/tpm2-tss/eventlog ;\
     mkdir -p /mnt/sys-root/run/systemd/ask-password /mnt/sys-root/run/systemd/machines /mnt/sys-root/run/systemd/seats /mnt/sys-root/run/systemd/sessions /mnt/sys-root/run/systemd/shutdown /mnt/sys-root/run/systemd/users ;\
@@ -81,7 +82,7 @@ RUN systemctl set-default multi-user.target; \
     getty.target \
     console-getty.service
 
-FROM scratch 
+FROM scratch
 COPY --from=stage2 / /
 
 ENV LANG=C.utf8

--- a/dockerfiles/al9/Dockerfile.default
+++ b/dockerfiles/al9/Dockerfile.default
@@ -34,8 +34,8 @@ RUN mkdir /mnt/sys-root; \
     --setopt install_weak_deps=false \
     --nodocs \
     krb5-libs ; \
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support   /mnt/sys-root/var/lib/dnf/history*  
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support   /mnt/sys-root/var/lib/dnf/history*
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ; \
     rm -rf /mnt/sys-root/var/cache/dnf/* /mnt/sys-root/var/lib/dnf/repos /mnt/sys-root/boot /mnt/sys-root/dev/null ; \
     rm -rf /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/var/log/*  ; \
@@ -58,8 +58,9 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     rm -rf /mnt/sys-root/usr/share/locale/en_US@piglati* /mnt/sys-root/run/blkid /mnt/sys-root/var/cache/dnf/.gpgkeyschecked.yum ; \
     rm -f /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/machine-id; 
-# AL9 specific hacks    
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
+# AL9 specific hacks
 RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump /mnt/sys-root/var/lib/tpm2-tss/system/keystore ;\
     mkdir -p /mnt/sys-root/run/cryptsetup /mnt/sys-root/run/lock/subsys /mnt/sys-root/run/log /mnt/sys-root/run/user /mnt/sys-root/run/tpm2-tss/eventlog ;\
     mkdir -p /mnt/sys-root/run/systemd/ask-password /mnt/sys-root/run/systemd/machines /mnt/sys-root/run/systemd/seats /mnt/sys-root/run/systemd/sessions /mnt/sys-root/run/systemd/shutdown /mnt/sys-root/run/systemd/users ;\
@@ -85,7 +86,7 @@ RUN systemctl set-default multi-user.target; \
     getty.target \
     console-getty.service
 
-FROM scratch 
+FROM scratch
 COPY --from=stage2 / /
 
 ENV LANG=C.utf8

--- a/dockerfiles/al9/Dockerfile.i686
+++ b/dockerfiles/al9/Dockerfile.i686
@@ -17,7 +17,7 @@ RUN mkdir /mnt/sys-root; \
     coreutils-single \
     dnf \
     findutils \
-    glibc-minimal-langpack \ 
+    glibc-minimal-langpack \
     hostname \
     iputils \
     langpacks-en \
@@ -27,7 +27,7 @@ RUN mkdir /mnt/sys-root; \
     tar \
     vim-minimal \
     yum \
-    xz \ 
+    xz \
     ; \
     yum --installroot /mnt/sys-root clean all; \
     rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.*; \
@@ -41,7 +41,8 @@ RUN mkdir /mnt/sys-root; \
     echo 'LANG="C.utf8"' >  /mnt/sys-root/etc/locale.conf; \
     echo 'container' > c/etc/dnf/vars/infra; \
     rm -f /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/machine-id;
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
 
 # Fix REPO files for updates and install compatable
 # Following fixes applies to all repo files
@@ -52,9 +53,9 @@ RUN sed -i 's/\/almalinux/\/vault/' /mnt/sys-root/etc/yum.repos.d/*.repo &>/dev/
     sed -i 's/# baseurl/baseurl/' /mnt/sys-root/etc/yum.repos.d/*.repo &>/dev/null; \
 # $basearch variable returns wrong path, fix with right path to keep installer happy
     sed -i 's/$basearch/i686/' /mnt/sys-root/etc/yum.repos.d/*.repo &>/dev/null;
-    
+
 # Create Fresh container image using copy
-FROM scratch 
+FROM scratch
 COPY --from=system-build /mnt/sys-root/ /
 
 ENV LANG=C.utf8
@@ -68,4 +69,3 @@ RUN systemctl set-default multi-user.target; \
     console-getty.service
 
 CMD ["/bin/bash"]
-

--- a/dockerfiles/al9/Dockerfile.init
+++ b/dockerfiles/al9/Dockerfile.init
@@ -23,7 +23,7 @@ RUN mkdir /mnt/sys-root; \
     libusbx \
     procps-ng \
     rootfiles \
-    systemd \    
+    systemd \
     tar \
     usermode \
     vim-minimal \
@@ -36,9 +36,9 @@ RUN mkdir /mnt/sys-root; \
     --releasever 9 \
     --setopt install_weak_deps=false \
     --nodocs \
-    krb5-libs ; \    
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support    
+    krb5-libs ; \
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/var/cache/dnf/* /mnt/sys-root/var/lib/dnf/repos; \
     rm -rf /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/*  /mnt/sys-root/run/blkid ; \
     mkdir -p /mnt/sys-root/run/lock; \
@@ -50,7 +50,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     touch /mnt/sys-root/etc/.pwd.lock; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     touch /mnt/sys-root/run/utmp ;\
-    chmod 664 /mnt/sys-root/run/utmp ;\    
+    chmod 664 /mnt/sys-root/run/utmp ;\
     echo '0.0 0 0.0' > /mnt/sys-root/etc/adjtime; \
     echo '0' >> /mnt/sys-root/etc/adjtime; \
     echo 'UTC' >> /mnt/sys-root/etc/adjtime; \
@@ -61,8 +61,9 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id /mnt/sys-root/var/cache/dnf/.gpgkeyschecked.yum ; \
-    touch /mnt/sys-root/etc/machine-id;
-# AL9 specific hacks    
+    touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf
+# AL9 specific hacks
 RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump /mnt/sys-root/var/lib/tpm2-tss/system/keystore ;\
     mkdir -p /mnt/sys-root/run/cryptsetup /mnt/sys-root/run/lock/subsys /mnt/sys-root/run/log /mnt/sys-root/run/user /mnt/sys-root/run/tpm2-tss/eventlog ;\
     mkdir -p /mnt/sys-root/run/systemd/ask-password /mnt/sys-root/run/systemd/machines /mnt/sys-root/run/systemd/seats /mnt/sys-root/run/systemd/sessions /mnt/sys-root/run/systemd/shutdown /mnt/sys-root/run/systemd/users ;\
@@ -92,7 +93,7 @@ RUN systemctl set-default multi-user.target; \
     systemd-random-seed.service \
     systemd-machine-id-commit.service
 
-FROM scratch 
+FROM scratch
 COPY --from=stage2 / /
 
 ENV LANG=C.utf8

--- a/dockerfiles/al9/Dockerfile.micro
+++ b/dockerfiles/al9/Dockerfile.micro
@@ -4,8 +4,8 @@ FROM ${SYSBASE} as system-build
 RUN mkdir -p /mnt/sys-root; \
     dnf install --installroot /mnt/sys-root coreutils-single glibc-minimal-langpack \
     --releasever 9 --setopt install_weak_deps=false --nodocs -y; \
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support 
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/lib/dnf /mnt/sys-root/var/log/yum.*; \
     /bin/date +%Y%m%d_%H%M > /mnt/sys-root/etc/BUILDTIME ;  \
     echo '%_install_langs C.utf8' > /mnt/sys-root/etc/rpm/macros.image-language-conf; \
@@ -13,6 +13,7 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     echo 'container' > /mnt/sys-root/etc/dnf/vars/infra; \
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf; \
     touch /mnt/sys-root/etc/.pwd.lock; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     rm -rf /mnt/sys-root/usr/share/locale/en* /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/hawkey.log ; \
@@ -26,7 +27,7 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     echo 'FONT="eurlatgr"' >> /mnt/sys-root/etc/vconsole.conf; \
     mkdir -p /mnt/sys-root/run/lock; \
     cd /mnt/sys-root/etc ; \
-    ln -s ../usr/share/zoneinfo/UTC localtime 
+    ln -s ../usr/share/zoneinfo/UTC localtime
 
 FROM scratch
 

--- a/dockerfiles/al9/Dockerfile.minimal
+++ b/dockerfiles/al9/Dockerfile.minimal
@@ -24,8 +24,8 @@ RUN mkdir /mnt/sys-root; \
     --setopt install_weak_deps=false \
     --nodocs \
     krb5-libs ; \
-    dnf --installroot /mnt/sys-root clean all; 
-# Additional hacks for kickstart file and backward compatable support    
+    dnf --installroot /mnt/sys-root clean all;
+# Additional hacks for kickstart file and backward compatable support
 RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/lib/dnf/repos; \
     rm -rf /mnt/sys-root/var/lib/dnf/history* /mnt/sys-root/var/log/hawkey.log /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/run/*; \
     mkdir -p /mnt/sys-root/run/lock; \
@@ -48,6 +48,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
+    touch /mnt/sys-root/etc/resolv.conf; \
     mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump ;\
     chmod 700 /mnt/sys-root/var/cache/private ; \
     chmod 700 /mnt/sys-root/var/lib/private ; \
@@ -58,10 +59,10 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     cd /mnt/sys-root/etc ; \
     ln -s ../usr/share/zoneinfo/UTC localtime ; \
     cd /mnt/sys-root/etc/systemd/system ; \
-    ln -s /usr/lib/systemd/system/multi-user.target default.target 
+    ln -s /usr/lib/systemd/system/multi-user.target default.target
 
 # Almalinux minimal build
-FROM scratch 
+FROM scratch
 COPY --from=system-build /mnt/sys-root/ /
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
Create an empty `/etc/resolv.conf` to fix inaccurate result while using Podman to inspect changes on image's filesystem.

Fixes #97 