### PR TITLE
Fix inaccurate diff result on podman v2

### DIFF
--- a/dockerfiles/al8/Dockerfile.base
+++ b/dockerfiles/al8/Dockerfile.base
@@ -47,7 +47,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 
 FROM scratch as stage2
 

--- a/dockerfiles/al8/Dockerfile.default
+++ b/dockerfiles/al8/Dockerfile.default
@@ -48,7 +48,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* ; \
     rm -rf /mnt/sys-root/usr/share/locale/en_US@piglati* /mnt/sys-root/run/blkid  ; \
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 
 FROM scratch as stage2
 COPY --from=system-build /mnt/sys-root/ /

--- a/dockerfiles/al8/Dockerfile.i686
+++ b/dockerfiles/al8/Dockerfile.i686
@@ -41,7 +41,8 @@ RUN mkdir /mnt/sys-root; \
     echo 'container' > /mnt/sys-root/etc/dnf/vars/infra; \
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 
 # Build a fresh container image using COPY
 FROM scratch

--- a/dockerfiles/al8/Dockerfile.init
+++ b/dockerfiles/al8/Dockerfile.init
@@ -48,7 +48,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 
 FROM scratch  as stage2
 

--- a/dockerfiles/al8/Dockerfile.micro
+++ b/dockerfiles/al8/Dockerfile.micro
@@ -15,6 +15,7 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/.pwd.lock; \
     touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     rm -rf /mnt/sys-root/usr/share/locale/en* /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/hawkey.log ; \
     echo '0.0 0 0.0' > /mnt/sys-root/etc/adjtime; \

--- a/dockerfiles/al8/Dockerfile.minimal
+++ b/dockerfiles/al8/Dockerfile.minimal
@@ -37,6 +37,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname; \
     cd /mnt/sys-root/etc ; \
     ln -s ../usr/share/zoneinfo/UTC localtime
 

--- a/dockerfiles/al9/Dockerfile.base
+++ b/dockerfiles/al9/Dockerfile.base
@@ -55,7 +55,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id /mnt/sys-root/var/cache/dnf/.gpgkeyschecked.yum ; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 # AL9 specific hacks
 RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump /mnt/sys-root/var/lib/tpm2-tss/system/keystore ;\
     mkdir -p /mnt/sys-root/run/cryptsetup /mnt/sys-root/run/lock/subsys /mnt/sys-root/run/log /mnt/sys-root/run/user /mnt/sys-root/run/tpm2-tss/eventlog ;\

--- a/dockerfiles/al9/Dockerfile.default
+++ b/dockerfiles/al9/Dockerfile.default
@@ -59,7 +59,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_US@piglati* /mnt/sys-root/run/blkid /mnt/sys-root/var/cache/dnf/.gpgkeyschecked.yum ; \
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 # AL9 specific hacks
 RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump /mnt/sys-root/var/lib/tpm2-tss/system/keystore ;\
     mkdir -p /mnt/sys-root/run/cryptsetup /mnt/sys-root/run/lock/subsys /mnt/sys-root/run/log /mnt/sys-root/run/user /mnt/sys-root/run/tpm2-tss/eventlog ;\

--- a/dockerfiles/al9/Dockerfile.i686
+++ b/dockerfiles/al9/Dockerfile.i686
@@ -42,7 +42,8 @@ RUN mkdir /mnt/sys-root; \
     echo 'container' > /mnt/sys-root/etc/dnf/vars/infra; \
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 
 # Fix REPO files for updates and install compatable
 # Following fixes applies to all repo files

--- a/dockerfiles/al9/Dockerfile.init
+++ b/dockerfiles/al9/Dockerfile.init
@@ -62,7 +62,8 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -rf /mnt/sys-root/usr/share/locale/en_CA/ /mnt/sys-root/usr/share/locale/en_GB/ /mnt/sys-root/usr/share/locale/en@* /mnt/sys-root/usr/share/locale/en  /mnt/sys-root/usr/share/locale/en*@* /mnt/sys-root/usr/share/i18n/charmaps /mnt/sys-root/usr/share/i18n/locales ;\
     rm -f /mnt/sys-root/etc/machine-id /mnt/sys-root/var/cache/dnf/.gpgkeyschecked.yum ; \
     touch /mnt/sys-root/etc/machine-id; \
-    touch /mnt/sys-root/etc/resolv.conf
+    touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname
 # AL9 specific hacks
 RUN mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump /mnt/sys-root/var/lib/tpm2-tss/system/keystore ;\
     mkdir -p /mnt/sys-root/run/cryptsetup /mnt/sys-root/run/lock/subsys /mnt/sys-root/run/log /mnt/sys-root/run/user /mnt/sys-root/run/tpm2-tss/eventlog ;\

--- a/dockerfiles/al9/Dockerfile.micro
+++ b/dockerfiles/al9/Dockerfile.micro
@@ -14,6 +14,7 @@ RUN rm -rf /mnt/sys-root/var/cache/dnf /mnt/sys-root/var/log/dnf* /mnt/sys-root/
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname; \
     touch /mnt/sys-root/etc/.pwd.lock; \
     chmod 600 /mnt/sys-root/etc/.pwd.lock; \
     rm -rf /mnt/sys-root/usr/share/locale/en* /mnt/sys-root/boot /mnt/sys-root/dev/null /mnt/sys-root/var/log/hawkey.log ; \

--- a/dockerfiles/al9/Dockerfile.minimal
+++ b/dockerfiles/al9/Dockerfile.minimal
@@ -49,6 +49,7 @@ RUN rm -rf /mnt/sys-root/var/log/dnf* /mnt/sys-root/var/log/yum.* /mnt/sys-root/
     rm -f /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/machine-id; \
     touch /mnt/sys-root/etc/resolv.conf; \
+    touch /mnt/sys-root/etc/hostname; \
     mkdir -p /mnt/sys-root/var/cache/private /mnt/sys-root/var/lib/private /mnt/sys-root/var/lib/systemd/coredump ;\
     chmod 700 /mnt/sys-root/var/cache/private ; \
     chmod 700 /mnt/sys-root/var/lib/private ; \


### PR DESCRIPTION
Create an empty /etc/hostname to fix inaccurate result while using Podman to inspect changes on image's filesystem.

Fixes #106 